### PR TITLE
Dospore/relayer optimisations

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -93,7 +93,7 @@ export async function createRelayer() {
       for (const { signingPayload } of intents) {
         if (requiresPriceCommit(signingPayload)) {
           const marketAddress = getMarketAddressFromIntent(signingPayload)
-          if (!!marketPriceCommits[marketAddress]) {
+          if (marketAddress in marketPriceCommits) {
             continue
           }
           marketPriceCommits[marketAddress] = buildPriceCommit(SDK, Chain.id, signingPayload)

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -108,7 +108,6 @@ export async function createRelayer() {
       const uos = priceCommitsBatch.concat(intentBatch)
 
       const entryPoint = relayerSmartClient.account.getEntryPoint().address
-
       const nonceKey = BigInt(intents[0].signingPayload.message.action.common.signer)
       const { uoHash, txHash } = await retryUserOpWithIncreasingTip(
         async (tipMultiplier: number, shouldWait?: boolean) => {

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -93,7 +93,7 @@ export async function createRelayer() {
       for (const { signingPayload } of intents) {
         if (requiresPriceCommit(signingPayload)) {
           const marketAddress = getMarketAddressFromIntent(signingPayload)
-          if (marketAddress in marketPriceCommits) {
+          if (marketPriceCommits[marketAddress] !== undefined) {
             continue
           }
           marketPriceCommits[marketAddress] = buildPriceCommit(SDK, Chain.id, signingPayload)


### PR DESCRIPTION
Trying to bring down the latency of relayed userOps. Makes it a little less readable but seeing up to 50% reduction locally. Around 20% reduction is the min I've seen. Also added dogstats, we could get more granular with checkpointing between buildUserOp, signUserOp and sendUserOp. From my local tests, the longest tasks are buildUserOp and waitForUserOpTransaction

- async eth price fetch
- async price commit builds
- reduce wait time interval of waitForUserOpTransaction
- add dogstats to track execution times