### PR TITLE
Check userOpReceipt for reverts

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gen:lens-artifact": "yarn compile && tsx --tsconfig ./tsconfig.release.json src/scripts/lensAbiCopy.ts && prettier --write src/constants/abi/*",
     "precommit": "yarn lint-staged",
     "gen:gql-typings": "graphql-codegen --config graph-codegen.ts",
-    "postinstall": "husky install",
+    "postinstall": "husky install && patch-package",
     "test": "vitest"
   },
   "license": "Apache-2.0",

--- a/patches/@aa-sdk+core+4.0.0-beta.9.patch
+++ b/patches/@aa-sdk+core+4.0.0-beta.9.patch
@@ -1,115 +1,11 @@
-diff --git a/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js b/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js
-index ba526ed..ab27ae0 100644
---- a/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js
-+++ b/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js
-@@ -195,12 +195,16 @@ export async function toSmartContractAccount(params) {
-         (() => {
-             throw new UpgradesNotSupportedError(source);
-         });
-+
-     const isAccountDeployed = async () => {
-+        console.log("Checking is account deployed");
-         const initCode = await getInitCode();
-         return initCode === "0x";
-     };
-+    let isDeployed = isAccountDeployed();
-+
-     const getNonce = async (nonceKey = 0n) => {
--        if (!(await isAccountDeployed())) {
-+        if (!(await isDeployed)) {
-             return 0n;
-         }
-         return entryPointContract.read.getNonce([
-@@ -273,6 +277,7 @@ export async function toSmartContractAccount(params) {
-         encodeUpgradeToAndCall: encodeUpgradeToAndCall_,
-         getEntryPoint: () => entryPoint,
-         isAccountDeployed,
-+        isDeployed,
-         getAccountNonce: getNonce,
-         signMessageWith6492,
-         signTypedDataWith6492,
-diff --git a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js
-index 0e0d1e7..d10ee11 100644
---- a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js
-+++ b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js
-@@ -39,8 +39,8 @@ export async function _initUserOperation(client, args) {
-             signature,
-         }
-         : {
--            factory: conditionalReturn(account.isAccountDeployed().then((deployed) => !deployed), account.getFactoryAddress),
--            factoryData: conditionalReturn(account.isAccountDeployed().then((deployed) => !deployed), account.getFactoryData),
-+            factory: conditionalReturn(account.isDeployed.then((deployed) => !deployed), account.getFactoryAddress),
-+            factoryData: conditionalReturn(account.isDeployed.then((deployed) => !deployed), account.getFactoryData),
-             sender: account.address,
-             nonce,
-             callData,
-diff --git a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js
-index 4ae9814..0f1b87c 100644
---- a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js
-+++ b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js
-@@ -1,18 +1,28 @@
- import { AccountNotFoundError } from "../../../errors/account.js";
- import { noopMiddleware } from "../../../middleware/noopMiddleware.js";
- import { bypassPaymasterAndData, resolveProperties, } from "../../../utils/index.js";
-+
- const asyncPipe = (...fns) => async (s, opts) => {
-     let result = s;
-     for (const fn of fns) {
-+      const startTime = performance.now();
-+      if (Array.isArray(fn)) {
-+        const results = await Promise.all(fn.map((fn_) => (fn_(result, opts))))
-+        result = results.reduce((o, r) => ({ ...o, ...r }), result)
-+      } else {
-         result = await fn(result, opts);
-+      }
-+      console.log(`Took ${(performance.now() - startTime) / 1000} seconds`, fn)
-     }
-     return result;
- };
-+
- export async function _runMiddlewareStack(client, args) {
-     const { uo, overrides, account = client.account, context } = args;
-     if (!account) {
-         throw new AccountNotFoundError();
-     }
-+
-     const { dummyPaymasterAndData, paymasterAndData, } = bypassPaymasterAndData(overrides)
-         ? {
-             dummyPaymasterAndData: async (uo, { overrides }) => {
-@@ -34,11 +44,20 @@ export async function _runMiddlewareStack(client, args) {
-             },
-             paymasterAndData: noopMiddleware,
-         }
--        : {
-+        :     {
-             dummyPaymasterAndData: client.middleware.dummyPaymasterAndData,
-             paymasterAndData: client.middleware.paymasterAndData,
-         };
--    const result = await asyncPipe(dummyPaymasterAndData, client.middleware.feeEstimator, client.middleware.gasEstimator, client.middleware.customMiddleware, paymasterAndData, client.middleware.userOperationSimulator)(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
-+    const result = await asyncPipe(
-+        dummyPaymasterAndData,
-+        [
-+          client.middleware.feeEstimator,
-+          client.middleware.gasEstimator,
-+          client.middleware.customMiddleware,
-+        ],
-+        paymasterAndData,
-+        client.middleware.userOperationSimulator
-+      )(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
-     return resolveProperties(result);
- }
- //# sourceMappingURL=runMiddlewareStack.js.map
-\ No newline at end of file
 diff --git a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js
-index 08ee28d..7fa7e72 100644
+index 08ee28d..16e0ccb 100644
 --- a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js
 +++ b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js
-@@ -53,4 +53,26 @@ export const waitForUserOperationTransaction = async (client, args) => {
-     }
+@@ -54,3 +54,33 @@ export const waitForUserOperationTransaction = async (client, args) => {
      throw new FailedToFindTransactionError(hash);
  };
--//# sourceMappingURL=waitForUserOperationTransacation.js.map
-\ No newline at end of file
+ //# sourceMappingURL=waitForUserOperationTransacation.js.map
 +
 +export const waitForUserOperationReceipt = async (client, args) => {
 +    if (!isBaseSmartAccountClient(client)) {
@@ -129,7 +25,14 @@ index 08ee28d..7fa7e72 100644
 +            .catch((e) => {
 +            Logger.error(`[SmartAccountProvider] waitForUserOperationTransaction error fetching receipt for ${hash}: ${e}`);
 +        });
-+        return receipt
++        if (receipt) {
++            return getTransaction(client, {
++                hash: receipt.receipt.transactionHash,
++            }).then((tx) => ({
++              hash: tx.hash,
++              userOpReceipt: receipt
++            }));
++        }
 +    }
 +    throw new FailedToFindTransactionError(hash);
 +};
@@ -146,65 +49,6 @@ index fa6e071..6611b78 100644
  export { createBundlerClient, createBundlerClientFromExisting, } from "./client/bundlerClient.js";
  export { bundlerActions } from "./client/decorators/bundlerClient.js";
  export { smartAccountClientActions } from "./client/decorators/smartAccountClient.js";
-diff --git a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js
-index bcb491c..1aff2ad 100644
---- a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js
-+++ b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js
-@@ -9,8 +9,14 @@ import { applyUserOpOverrideOrFeeOption } from "../../utils/userop.js";
-  * @returns {ClientMiddlewareFn} middleware execution function used to estimate gas for user operations
-  */
- export const defaultGasEstimator = (client) => async (struct, { account, overrides, feeOptions }) => {
-+    let start = performance.now();
-     const request = deepHexlify(await resolveProperties(struct));
-+    console.log(`GE<resolveProperties>: ${(performance.now() - start) / 1000} seconds`)
-+
-+    start = performance.now();
-     const estimates = await client.estimateUserOperationGas(request, account.getEntryPoint().address, overrides?.stateOverride);
-+    console.log(`GE<estimateUserOpGas>: ${(performance.now() - start) / 1000} seconds`)
-+
-     const callGasLimit = applyUserOpOverrideOrFeeOption(estimates.callGasLimit, overrides?.callGasLimit, feeOptions?.callGasLimit);
-     const verificationGasLimit = applyUserOpOverrideOrFeeOption(estimates.verificationGasLimit, overrides?.verificationGasLimit, feeOptions?.verificationGasLimit);
-     const preVerificationGas = applyUserOpOverrideOrFeeOption(estimates.preVerificationGas, overrides?.preVerificationGas, feeOptions?.preVerificationGas);
-diff --git a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js
-index 6fbb349..3673809 100644
---- a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js
-+++ b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js
-@@ -7,6 +7,7 @@
-  * @returns {Promise<UserOperationStruct>} a promise that resolves to the modified user operation structure
-  */
- export const defaultPaymasterAndData = async (struct, { account }) => {
-+    console.log("Appending paymaster and data")
-     const entryPoint = account.getEntryPoint();
-     if (entryPoint.version === "0.6.0") {
-         struct.paymasterAndData = "0x";
-diff --git a/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js b/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js
-index 3bb59c8..9bb8a66 100644
---- a/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js
-+++ b/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js
-@@ -24,7 +24,10 @@ import { deepHexlify, resolveProperties, } from "../utils/index.js";
-  */
- export function erc7677Middleware(params) {
-     const dummyPaymasterAndData = async (uo, { client, account, feeOptions, overrides }) => {
-+        const startResolve = performance.now();
-         const userOp = deepHexlify(await resolveProperties(uo));
-+        console.log(`DPM<resolveProperties>: ${(performance.now() - startResolve) / 1000} seconds`)
-+
-         // Those values will be set after fee estimation.
-         userOp.maxFeePerGas = "0x0";
-         userOp.maxPriorityFeePerGas = "0x0";
-@@ -44,10 +47,12 @@ export function erc7677Middleware(params) {
-         }
-         const erc7677client = client;
-         // TODO: probably need to handle the sponsor and isFinal fields
-+        const startStub = performance.now()
-         const { paymaster, paymasterAndData, paymasterData, paymasterPostOpGasLimit, paymasterVerificationGasLimit, } = await erc7677client.request({
-             method: "pm_getPaymasterStubData",
-             params: [userOp, entrypoint.address, toHex(client.chain.id), context],
-         });
-+        console.log(`DPM<getPaymasterStubData>: ${(performance.now() - startStub) / 1000} seconds`)
-         if (entrypoint.version === "0.6.0") {
-             return {
-                 ...uo,
 diff --git a/node_modules/@aa-sdk/core/dist/types/index.d.ts b/node_modules/@aa-sdk/core/dist/types/index.d.ts
 index 24c5baf..75d8816 100644
 --- a/node_modules/@aa-sdk/core/dist/types/index.d.ts

--- a/patches/@aa-sdk+core+4.0.0-beta.9.patch
+++ b/patches/@aa-sdk+core+4.0.0-beta.9.patch
@@ -1,0 +1,220 @@
+diff --git a/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js b/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js
+index ba526ed..ab27ae0 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js
++++ b/node_modules/@aa-sdk/core/dist/esm/account/smartContractAccount.js
+@@ -195,12 +195,16 @@ export async function toSmartContractAccount(params) {
+         (() => {
+             throw new UpgradesNotSupportedError(source);
+         });
++
+     const isAccountDeployed = async () => {
++        console.log("Checking is account deployed");
+         const initCode = await getInitCode();
+         return initCode === "0x";
+     };
++    let isDeployed = isAccountDeployed();
++
+     const getNonce = async (nonceKey = 0n) => {
+-        if (!(await isAccountDeployed())) {
++        if (!(await isDeployed)) {
+             return 0n;
+         }
+         return entryPointContract.read.getNonce([
+@@ -273,6 +277,7 @@ export async function toSmartContractAccount(params) {
+         encodeUpgradeToAndCall: encodeUpgradeToAndCall_,
+         getEntryPoint: () => entryPoint,
+         isAccountDeployed,
++        isDeployed,
+         getAccountNonce: getNonce,
+         signMessageWith6492,
+         signTypedDataWith6492,
+diff --git a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js
+index 0e0d1e7..d10ee11 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js
++++ b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/initUserOperation.js
+@@ -39,8 +39,8 @@ export async function _initUserOperation(client, args) {
+             signature,
+         }
+         : {
+-            factory: conditionalReturn(account.isAccountDeployed().then((deployed) => !deployed), account.getFactoryAddress),
+-            factoryData: conditionalReturn(account.isAccountDeployed().then((deployed) => !deployed), account.getFactoryData),
++            factory: conditionalReturn(account.isDeployed.then((deployed) => !deployed), account.getFactoryAddress),
++            factoryData: conditionalReturn(account.isDeployed.then((deployed) => !deployed), account.getFactoryData),
+             sender: account.address,
+             nonce,
+             callData,
+diff --git a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js
+index 4ae9814..0f1b87c 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js
++++ b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/internal/runMiddlewareStack.js
+@@ -1,18 +1,28 @@
+ import { AccountNotFoundError } from "../../../errors/account.js";
+ import { noopMiddleware } from "../../../middleware/noopMiddleware.js";
+ import { bypassPaymasterAndData, resolveProperties, } from "../../../utils/index.js";
++
+ const asyncPipe = (...fns) => async (s, opts) => {
+     let result = s;
+     for (const fn of fns) {
++      const startTime = performance.now();
++      if (Array.isArray(fn)) {
++        const results = await Promise.all(fn.map((fn_) => (fn_(result, opts))))
++        result = results.reduce((o, r) => ({ ...o, ...r }), result)
++      } else {
+         result = await fn(result, opts);
++      }
++      console.log(`Took ${(performance.now() - startTime) / 1000} seconds`, fn)
+     }
+     return result;
+ };
++
+ export async function _runMiddlewareStack(client, args) {
+     const { uo, overrides, account = client.account, context } = args;
+     if (!account) {
+         throw new AccountNotFoundError();
+     }
++
+     const { dummyPaymasterAndData, paymasterAndData, } = bypassPaymasterAndData(overrides)
+         ? {
+             dummyPaymasterAndData: async (uo, { overrides }) => {
+@@ -34,11 +44,20 @@ export async function _runMiddlewareStack(client, args) {
+             },
+             paymasterAndData: noopMiddleware,
+         }
+-        : {
++        :     {
+             dummyPaymasterAndData: client.middleware.dummyPaymasterAndData,
+             paymasterAndData: client.middleware.paymasterAndData,
+         };
+-    const result = await asyncPipe(dummyPaymasterAndData, client.middleware.feeEstimator, client.middleware.gasEstimator, client.middleware.customMiddleware, paymasterAndData, client.middleware.userOperationSimulator)(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
++    const result = await asyncPipe(
++        dummyPaymasterAndData,
++        [
++          client.middleware.feeEstimator,
++          client.middleware.gasEstimator,
++          client.middleware.customMiddleware,
++        ],
++        paymasterAndData,
++        client.middleware.userOperationSimulator
++      )(uo, { overrides, feeOptions: client.feeOptions, account, client, context });
+     return resolveProperties(result);
+ }
+ //# sourceMappingURL=runMiddlewareStack.js.map
+\ No newline at end of file
+diff --git a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js
+index 08ee28d..7fa7e72 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js
++++ b/node_modules/@aa-sdk/core/dist/esm/actions/smartAccount/waitForUserOperationTransacation.js
+@@ -53,4 +53,26 @@ export const waitForUserOperationTransaction = async (client, args) => {
+     }
+     throw new FailedToFindTransactionError(hash);
+ };
+-//# sourceMappingURL=waitForUserOperationTransacation.js.map
+\ No newline at end of file
++
++export const waitForUserOperationReceipt = async (client, args) => {
++    if (!isBaseSmartAccountClient(client)) {
++        throw new IncompatibleClientError("BaseSmartAccountClient", "waitForUserOperationTransaction", client);
++    }
++    const { hash, retries = {
++        maxRetries: client.txMaxRetries,
++        intervalMs: client.txRetryIntervalMs,
++        multiplier: client.txRetryMultiplier,
++    }, } = args;
++    for (let i = 0; i < retries.maxRetries; i++) {
++        const txRetryIntervalWithJitterMs = retries.intervalMs * Math.pow(retries.multiplier, i) +
++            Math.random() * 100;
++        await new Promise((resolve) => setTimeout(resolve, txRetryIntervalWithJitterMs));
++        const receipt = await client
++            .getUserOperationReceipt(hash)
++            .catch((e) => {
++            Logger.error(`[SmartAccountProvider] waitForUserOperationTransaction error fetching receipt for ${hash}: ${e}`);
++        });
++        return receipt
++    }
++    throw new FailedToFindTransactionError(hash);
++};
+diff --git a/node_modules/@aa-sdk/core/dist/esm/index.js b/node_modules/@aa-sdk/core/dist/esm/index.js
+index fa6e071..6611b78 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/index.js
++++ b/node_modules/@aa-sdk/core/dist/esm/index.js
+@@ -12,7 +12,7 @@ export { dropAndReplaceUserOperation } from "./actions/smartAccount/dropAndRepla
+ export { sendTransaction } from "./actions/smartAccount/sendTransaction.js";
+ export { sendTransactions } from "./actions/smartAccount/sendTransactions.js";
+ export { sendUserOperation } from "./actions/smartAccount/sendUserOperation.js";
+-export { waitForUserOperationTransaction } from "./actions/smartAccount/waitForUserOperationTransacation.js";
++export { waitForUserOperationTransaction, waitForUserOperationReceipt } from "./actions/smartAccount/waitForUserOperationTransacation.js";
+ export { createBundlerClient, createBundlerClientFromExisting, } from "./client/bundlerClient.js";
+ export { bundlerActions } from "./client/decorators/bundlerClient.js";
+ export { smartAccountClientActions } from "./client/decorators/smartAccountClient.js";
+diff --git a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js
+index bcb491c..1aff2ad 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js
++++ b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/gasEstimator.js
+@@ -9,8 +9,14 @@ import { applyUserOpOverrideOrFeeOption } from "../../utils/userop.js";
+  * @returns {ClientMiddlewareFn} middleware execution function used to estimate gas for user operations
+  */
+ export const defaultGasEstimator = (client) => async (struct, { account, overrides, feeOptions }) => {
++    let start = performance.now();
+     const request = deepHexlify(await resolveProperties(struct));
++    console.log(`GE<resolveProperties>: ${(performance.now() - start) / 1000} seconds`)
++
++    start = performance.now();
+     const estimates = await client.estimateUserOperationGas(request, account.getEntryPoint().address, overrides?.stateOverride);
++    console.log(`GE<estimateUserOpGas>: ${(performance.now() - start) / 1000} seconds`)
++
+     const callGasLimit = applyUserOpOverrideOrFeeOption(estimates.callGasLimit, overrides?.callGasLimit, feeOptions?.callGasLimit);
+     const verificationGasLimit = applyUserOpOverrideOrFeeOption(estimates.verificationGasLimit, overrides?.verificationGasLimit, feeOptions?.verificationGasLimit);
+     const preVerificationGas = applyUserOpOverrideOrFeeOption(estimates.preVerificationGas, overrides?.preVerificationGas, feeOptions?.preVerificationGas);
+diff --git a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js
+index 6fbb349..3673809 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js
++++ b/node_modules/@aa-sdk/core/dist/esm/middleware/defaults/paymasterAndData.js
+@@ -7,6 +7,7 @@
+  * @returns {Promise<UserOperationStruct>} a promise that resolves to the modified user operation structure
+  */
+ export const defaultPaymasterAndData = async (struct, { account }) => {
++    console.log("Appending paymaster and data")
+     const entryPoint = account.getEntryPoint();
+     if (entryPoint.version === "0.6.0") {
+         struct.paymasterAndData = "0x";
+diff --git a/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js b/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js
+index 3bb59c8..9bb8a66 100644
+--- a/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js
++++ b/node_modules/@aa-sdk/core/dist/esm/middleware/erc7677middleware.js
+@@ -24,7 +24,10 @@ import { deepHexlify, resolveProperties, } from "../utils/index.js";
+  */
+ export function erc7677Middleware(params) {
+     const dummyPaymasterAndData = async (uo, { client, account, feeOptions, overrides }) => {
++        const startResolve = performance.now();
+         const userOp = deepHexlify(await resolveProperties(uo));
++        console.log(`DPM<resolveProperties>: ${(performance.now() - startResolve) / 1000} seconds`)
++
+         // Those values will be set after fee estimation.
+         userOp.maxFeePerGas = "0x0";
+         userOp.maxPriorityFeePerGas = "0x0";
+@@ -44,10 +47,12 @@ export function erc7677Middleware(params) {
+         }
+         const erc7677client = client;
+         // TODO: probably need to handle the sponsor and isFinal fields
++        const startStub = performance.now()
+         const { paymaster, paymasterAndData, paymasterData, paymasterPostOpGasLimit, paymasterVerificationGasLimit, } = await erc7677client.request({
+             method: "pm_getPaymasterStubData",
+             params: [userOp, entrypoint.address, toHex(client.chain.id), context],
+         });
++        console.log(`DPM<getPaymasterStubData>: ${(performance.now() - startStub) / 1000} seconds`)
+         if (entrypoint.version === "0.6.0") {
+             return {
+                 ...uo,
+diff --git a/node_modules/@aa-sdk/core/dist/types/index.d.ts b/node_modules/@aa-sdk/core/dist/types/index.d.ts
+index 24c5baf..75d8816 100644
+--- a/node_modules/@aa-sdk/core/dist/types/index.d.ts
++++ b/node_modules/@aa-sdk/core/dist/types/index.d.ts
+@@ -16,7 +16,7 @@ export { sendTransaction } from "./actions/smartAccount/sendTransaction.js";
+ export { sendTransactions } from "./actions/smartAccount/sendTransactions.js";
+ export { sendUserOperation } from "./actions/smartAccount/sendUserOperation.js";
+ export type * from "./actions/smartAccount/types.js";
+-export { waitForUserOperationTransaction } from "./actions/smartAccount/waitForUserOperationTransacation.js";
++export { waitForUserOperationTransaction, waitForUserOperationReceipt } from "./actions/smartAccount/waitForUserOperationTransacation.js";
+ export type * from "./client/bundlerClient.js";
+ export { createBundlerClient, createBundlerClientFromExisting, } from "./client/bundlerClient.js";
+ export type * from "./client/decorators/bundlerClient.js";

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -20,7 +20,7 @@ import tracer from '../tracer.js'
 import { EthOracleFetcher } from '../utils/ethOracleFetcher.js'
 import { CallGasLimitMultiplier } from '../constants/relayer.js'
 import { Address } from 'hardhat-deploy/dist/types.js'
-import { UserOperationReceipt, waitForUserOperationReceipt } from 'viem/account-abstraction'
+import { waitForUserOperationReceipt } from 'viem/account-abstraction'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unreachable code error
@@ -154,12 +154,10 @@ export async function createRelayer() {
             tipMultiplier
           })
 
-          let userOpReceipt: UserOperationReceipt
+          let userOpReceipt = undefined
           if (shouldWait) {
-            // userOpReceipt = await relayerSmartClient.waitForUserOperationReceipt({
             userOpReceipt = await waitForUserOperationReceipt(relayerSmartClient, {
               hash: uoHash,
-              retryCount: relayerSmartClient.txMaxRetries, // default 5
               pollingInterval: 500 // default 1000
             })
               .catch(injectUOError(UOError.FailedWaitForOperation))
@@ -171,7 +169,7 @@ export async function createRelayer() {
           }
           return ({
             uoHash,
-            txHash
+            txHash: userOpReceipt?.receipt?.transactionHash
           })
         }, {
           maxRetry: meta?.maxRetries,

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -81,7 +81,7 @@ export async function createRelayer() {
       }
     }
 
-    let erroredUoHash, erroredTxHash
+    let erroredTxHash
     try {
       const latestEthPrice_ = ethOracleFetcher.getLastPriceBig6()
         .catch((e) => {
@@ -167,7 +167,6 @@ export async function createRelayer() {
             txHash = userOpReceipt?.receipt?.transactionHash
 
             if (userOpReceipt?.success === false) {
-              erroredUoHash = uoHash
               erroredTxHash = txHash
               throw new Error(`UserOp reverted: ${userOpReceipt.reason}`)
             }
@@ -194,7 +193,7 @@ export async function createRelayer() {
       tracer.dogstatsd.increment('relayer.userOp.reverted', 1, {
         chain: Chain.id,
       })
-      res.send(JSON.stringify({ success: false, status: UserOpStatus.Failed, error: `Unable to relay transaction: ${e.message}`, uoHash: erroredUoHash, txHash: erroredTxHash }))
+      res.send(JSON.stringify({ success: false, status: UserOpStatus.Failed, error: `Unable to relay transaction: ${e.message}`, txHash: erroredTxHash }))
     }
   })
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -165,6 +165,11 @@ export async function createRelayer() {
             })
               .catch(injectUOError(UOError.FailedWaitForOperation))
             console.log(`UserOp confirmed: ${txHash}`)
+
+            const receipt = await relayerSmartClient.getUserOperationReceipt(uoHash)
+            if (receipt?.success === false) {
+              throw new Error(`UserOp reverted: ${receipt.reason}`)
+            }
           }
           return ({
             uoHash,

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -157,7 +157,7 @@ export async function createRelayer() {
 
           let txHash
           if (shouldWait) {
-            const userOpReceipt = await waitForUserOperationReceipt(relayerSmartClient, {
+            const { userOpReceipt, hash } = await waitForUserOperationReceipt(relayerSmartClient, {
               hash: uoHash,
               retries: {
                 maxRetries: relayerSmartClient.txMaxRetries, // default 5
@@ -166,7 +166,7 @@ export async function createRelayer() {
               }
             })
               .catch(injectUOError(UOError.FailedWaitForOperation))
-            txHash = userOpReceipt?.receipt?.transactionHash
+            txHash = hash
             console.log(`UserOp confirmed: ${txHash}`)
             if (userOpReceipt?.success === false) {
               erroredTxHash = txHash


### PR DESCRIPTION
Alan forwarded a request to return `success: false` if the internal userOp reverts but the transaction succeeds.

Note: Alchemy doesnt have a waitForReceipt, but their function actually just waits for the receipt and then only returns the txHash, kind of annoying but I just created a new func to try and avoid making side effects.

Viem waitForUserOperationReceipt is much slower as alchemy queries the rundler directly. This also doesnt add any latency since its just returning extra information from waitForUserOperationTransaction